### PR TITLE
Another attempt at solving CircleCI MEDIA_ROOT issue.

### DIFF
--- a/pylabber/settings.py
+++ b/pylabber/settings.py
@@ -128,7 +128,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Media directory
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
 
-MEDIA_ROOT = env("MEDIA_ROOT") or os.path.join(BASE_DIR, "media")
+MEDIA_ROOT = env("MEDIA_ROOT")
 MEDIA_URL = "/media/"
 
 # Static directory

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skipdist = true
 
 [testenv]
 passenv = *
+setenv =
+    MEDIA_ROOT = {env:MEDIA_ROOT:{toxinidir}/media/}
 deps =
     -rrequirements.txt
     pytest


### PR DESCRIPTION
Added default value to _tox.ini_ instead of trying to set it in _settings.py_.