### PR TITLE
Added DB environment variables to CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       - image: themattrix/tox
         environment:
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
+          DB_NAME: circle_test
+          DB_USER: root
+          DB_PASSWORD: password
       - image: circleci/postgres:11
         environment:
           POSTGRES_USER: root


### PR DESCRIPTION
Added DB_NAME, DB_USER, and DB_PASSWORD environment variables to CircleCI configuration, trying to fix 'django.db.utils.OperationalError: FATAL:  role postgres does not exist'  when running tests.