### PR TITLE
Added a CELERY_RESULT_EXPIRES = 0 setting to prevent TaskResult cleanp.

### DIFF
--- a/pylabber/settings.py
+++ b/pylabber/settings.py
@@ -372,3 +372,4 @@ if USE_TZ:
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_TASK_TRACK_STARTED = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+CELERY_RESULT_EXPIRES = 0


### PR DESCRIPTION
:warning: @Aharonyn 